### PR TITLE
🧹 [Code Health] Remove unused `run_within_dir` function

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,5 @@
 """Test utilities for copier template testing."""
 
-import os
-from contextlib import contextmanager
 from pathlib import Path
 
 import yaml
@@ -22,21 +20,6 @@ def is_valid_yaml(path: Path) -> bool:
         return True
     except (FileNotFoundError, yaml.YAMLError, OSError):
         return False
-
-
-@contextmanager
-def run_within_dir(path: Path):
-    """Context manager to temporarily change working directory.
-
-    Args:
-        path: Directory to change to.
-    """
-    old_cwd = os.getcwd()
-    try:
-        os.chdir(path)
-        yield
-    finally:
-        os.chdir(old_cwd)
 
 
 def file_contains_text(file_path: Path, text: str) -> bool:


### PR DESCRIPTION
🎯 **What:** Removed the unused `run_within_dir` context manager and its corresponding unused imports from `tests/utils.py`.
💡 **Why:** It was dead code that was no longer used in the codebase. Removing it improves maintainability and readability by reducing clutter.
✅ **Verification:** Verified with `grep` that `run_within_dir` is not used anywhere else in the `tests/` directory. Ran the test suite to ensure no regressions were introduced.
✨ **Result:** A cleaner `tests/utils.py` file with no dead code.

---
*PR created automatically by Jules for task [9615087054624693498](https://jules.google.com/task/9615087054624693498) started by @tjzegmott*